### PR TITLE
strip timestamps button, click to select file, configurable line px

### DIFF
--- a/frontend/src/components/Magician.vue
+++ b/frontend/src/components/Magician.vue
@@ -764,9 +764,10 @@ const saveImage = async () => {
       ctx.scale(chatTransform.scale, chatTransform.scale);
 
       // Set up text rendering to match exactly with the preview
-      ctx.font = '12px "Arial Black", Arial, sans-serif';
+      ctx.font = '700 12px Arial, sans-serif';
       ctx.textBaseline = 'top';
       ctx.textRendering = 'geometricPrecision';
+      ctx.letterSpacing = '0px';
       
       let currentY = 0;
       const TEXT_OFFSET_Y = 1; // Consistent with preview
@@ -1799,9 +1800,9 @@ const handleDropZoneClick = (event: Event) => {
 .chat-line {
   position: relative;
   display: block;
-  font-family: 'Arial Black', sans-serif;
+  font-family: Arial, sans-serif;
   font-size: 12px;
-  line-height: 16px;
+  line-height: 1.3;
   padding: 0;
   white-space: pre-wrap;
   overflow-wrap: break-word;
@@ -1816,6 +1817,9 @@ const handleDropZoneClick = (event: Event) => {
     1px -1px 0 #000,
     1px 0 0 #000,
     1px 1px 0 #000;
+  -webkit-font-smoothing: none !important;
+  font-weight: 700;
+  letter-spacing: 0;
 }
 
 .chat-text {
@@ -1823,6 +1827,8 @@ const handleDropZoneClick = (event: Event) => {
   padding-right: 5px;
   user-select: text !important;
   cursor: text;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 .with-black-bar {

--- a/frontend/src/components/Magician.vue
+++ b/frontend/src/components/Magician.vue
@@ -52,6 +52,9 @@ const contentAreaRef = ref<HTMLElement | null>(null); // Reference to content ar
 const dropzoneScale = ref(1); // Scale factor for the dropzone to fit screen
 const isScaledDown = ref(false); // Flag to track if the dropzone is scaled down
 
+// Add to the script setup section near the other state variables
+const chatLineWidth = ref(640);
+
 // Calculate necessary scale factor to fit dropzone in available viewport
 const calculateDropzoneScale = () => {
   if (!contentAreaRef.value || !dropZoneWidth.value || !dropZoneHeight.value) return;
@@ -968,7 +971,7 @@ const saveImage = async () => {
       let lineIndex = 0;
       // FIXED: Use the explicit width from the CSS rule (.chat-line { width: 640px; }) 
       // minus horizontal padding (4px each side) for accurate wrapping.
-      const maxTextWidth = 640 - 8; 
+      const maxTextWidth = chatLineWidth.value - 8; 
 
       for (const line of parsedChatLines.value) {
         // Get the raw text content, ensuring HTML entities are decoded for measurement
@@ -1309,7 +1312,8 @@ const saveEditorState = () => {
     showBlackBars: showBlackBars.value,
     censoredRegions: censoredRegions.value,
     selectedText: { ...selectedText },
-    stripTimestamps: stripTimestamps.value // Save the new option
+    stripTimestamps: stripTimestamps.value,
+    chatLineWidth: chatLineWidth.value
   };
   Cookies.set('editorState', JSON.stringify(state), { expires: 365 });
 };
@@ -1332,6 +1336,7 @@ const loadEditorState = () => {
       censoredRegions.value = state.censoredRegions || [];
       Object.assign(selectedText, state.selectedText || { lineIndex: -1, startOffset: 0, endOffset: 0, text: '' });
       stripTimestamps.value = state.stripTimestamps || false; // Load the new option
+      chatLineWidth.value = state.chatLineWidth || 640;
       
       // If there's chat text, parse it
       if (chatlogText.value) {
@@ -1373,7 +1378,8 @@ watch([
   showBlackBars,
   censoredRegions,
   () => ({ ...selectedText }),
-  stripTimestamps // Watch the new option
+  stripTimestamps,
+  chatLineWidth
 ], () => {
   saveEditorState();
 }, { deep: true });
@@ -1486,6 +1492,20 @@ const handleDropZoneClick = (event: Event) => {
           style="max-width: 120px;"
           prepend-inner-icon="mdi-arrow-expand-vertical"
         ></v-text-field>
+        <v-text-field
+          v-model.number="chatLineWidth"
+          label="Line Width"
+          type="number"
+          density="compact"
+          hide-details
+          variant="solo-filled"
+          flat
+          style="max-width: 120px;"
+          prepend-inner-icon="mdi-format-line-spacing"
+          min="300"
+          max="1200"
+          @change="renderKey++"
+        ></v-text-field>
       </div>
 
       <v-spacer></v-spacer>
@@ -1562,7 +1582,6 @@ const handleDropZoneClick = (event: Event) => {
           </template>
         </v-tooltip>
       </div>
-
     </v-toolbar>
 
     <!-- Added Alert Banner for Known Issue -->
@@ -1784,9 +1803,9 @@ const handleDropZoneClick = (event: Event) => {
   font-size: 12px;
   line-height: 16px;
   padding: 0;
-  white-space: pre-wrap; /* Preserve spaces and wrap text */
-  overflow-wrap: break-word; /* Break words to prevent overflow */
-  width: 640px; /* Fixed width that will force consistent 80-character wrapping */ 
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  width: v-bind('chatLineWidth + "px"');
   margin: 0;
   text-shadow: 
     -1px -1px 0 #000,


### PR DESCRIPTION
top left of UI there is now a button that will strip timestamps from parsed text, as well as the drag option now allowing a user to click it to select a file instead.

this config adds a text field in the toolbar for setting the line width in pixels. the width can range from 300 to 1200 pixels, with a default of 640px. changes to the width are saved in cookies and will be preserved between sessions.
